### PR TITLE
Fix go.mod file not found error on latest golang version

### DIFF
--- a/echo-service/Dockerfile
+++ b/echo-service/Dockerfile
@@ -1,7 +1,9 @@
 # Build
 FROM golang:alpine AS builder
 RUN mkdir /src
-ADD echo.go /src
+
+COPY go.mod /src
+COPY echo.go /src
 RUN cd /src; go build -o echo
 
 # Final

--- a/echo-service/go.mod
+++ b/echo-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/mikejoh/echo-service
+
+go 1.18


### PR DESCRIPTION
## Outline of issue

I hit the below error while I tried `docker-compose up`. This is because your file structure is not compatible with latest go module system, but you still pull latest Golang.

```
 => ERROR [builder 4/4] RUN cd /src; go build -o echo                                                                                                                                      0.2s
------
 > [builder 4/4] RUN cd /src; go build -o echo:
#0 0.238 go: go.mod file not found in current directory or any parent directory; see 'go help modules'
------
```

## Solutions
- Add `go.mod`
- Load `go.mod` in Dockerfile